### PR TITLE
feat(#zpnfg): add BillSnapExceptionHandler

### DIFF
--- a/src/main/java/proj/kedabra/billsnap/ApiError.java
+++ b/src/main/java/proj/kedabra/billsnap/ApiError.java
@@ -1,0 +1,42 @@
+package proj.kedabra.billsnap;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+import lombok.Data;
+
+@Data
+public class ApiError {
+
+    private final HttpStatus status;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private final ZonedDateTime timestamp = ZonedDateTime.now();
+
+    private final String message;
+
+    private List<ApiSubError> errors = new ArrayList<>();
+
+    public ApiError(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public ApiError(HttpStatus status, String message, List<ObjectError> errors) {
+        this(status, message);
+        this.errors = errors.stream()
+                .filter(FieldError.class::isInstance)
+                .map(FieldError.class::cast)
+                .map(ApiSubError::new)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/proj/kedabra/billsnap/ApiSubError.java
+++ b/src/main/java/proj/kedabra/billsnap/ApiSubError.java
@@ -1,0 +1,32 @@
+package proj.kedabra.billsnap;
+
+import org.springframework.validation.FieldError;
+
+import lombok.Data;
+
+@Data
+public class ApiSubError {
+
+    private Object[] arguments;
+
+    private String field;
+
+    private String objectName;
+
+    private Object rejectedValue;
+
+    private String message;
+
+    private String errorCode;
+
+    public ApiSubError(FieldError error) {
+        this.arguments = error.getArguments();
+        this.field = error.getField();
+        this.objectName = error.getObjectName();
+        this.rejectedValue = error.getRejectedValue();
+        this.message = error.getDefaultMessage();
+        this.errorCode = error.getCode();
+    }
+
+
+}

--- a/src/main/java/proj/kedabra/billsnap/BillSnapExceptionHandler.java
+++ b/src/main/java/proj/kedabra/billsnap/BillSnapExceptionHandler.java
@@ -1,0 +1,29 @@
+package proj.kedabra.billsnap;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import proj.kedabra.billsnap.exception.FieldValidationException;
+
+@ControllerAdvice
+public class BillSnapExceptionHandler extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(FieldValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ResponseEntity<ApiError> handleFieldValidation(final FieldValidationException ex) {
+        var error = new ApiError(HttpStatus.BAD_REQUEST, ex.getMessage(), ex.getErrors());
+        return new ResponseEntity<>(error, error.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    protected ResponseEntity<ApiError> handleUnknownException(final Exception ex) {
+        var error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown error occurred. Please try again later");
+        return new ResponseEntity<>(error, error.getStatus());
+    }
+}

--- a/src/main/java/proj/kedabra/billsnap/exception/BillSnapException.java
+++ b/src/main/java/proj/kedabra/billsnap/exception/BillSnapException.java
@@ -1,0 +1,18 @@
+package proj.kedabra.billsnap.exception;
+
+import lombok.Getter;
+
+@Getter
+abstract class BillSnapException extends RuntimeException {
+
+    private static final long serialVersionUID = 3872812859698299907L;
+
+    private final String message;
+
+    private final Throwable ex;
+
+    BillSnapException(final String message, final Throwable ex) {
+        this.message = message;
+        this.ex = ex;
+    }
+}

--- a/src/main/java/proj/kedabra/billsnap/exception/FieldValidationException.java
+++ b/src/main/java/proj/kedabra/billsnap/exception/FieldValidationException.java
@@ -1,0 +1,20 @@
+package proj.kedabra.billsnap.exception;
+
+import java.util.List;
+
+import org.springframework.validation.ObjectError;
+
+import lombok.Getter;
+
+@Getter
+public class FieldValidationException extends BillSnapException {
+
+    private static final long serialVersionUID = 4200035927552159732L;
+
+    private List<ObjectError> errors;
+
+    public FieldValidationException(String message, Throwable ex, List<ObjectError> errors) {
+        super(message, ex);
+        this.errors = errors;
+    }
+}

--- a/src/test/java/proj/kedabra/billsnap/ApiErrorTest.java
+++ b/src/test/java/proj/kedabra/billsnap/ApiErrorTest.java
@@ -1,0 +1,58 @@
+package proj.kedabra.billsnap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+
+class ApiErrorTest {
+
+
+    @Test
+    @DisplayName("Should have all fields mapped")
+    void shouldHaveAllFieldsMapped() {
+
+        //Given
+        List<ObjectError> errors = IntStream.range(0, 5)
+                .filter(n -> n % 2 == 0)
+                .mapToObj(FieldErrorFixture::getDefault)
+                .collect(Collectors.toList());
+
+        //When
+        var apiError = new ApiError(HttpStatus.I_AM_A_TEAPOT, "TESTMESSAGE", errors);
+
+        //Then
+        assertEquals(HttpStatus.I_AM_A_TEAPOT, apiError.getStatus());
+        assertEquals("TESTMESSAGE", apiError.getMessage());
+        assertEquals(3, apiError.getErrors().size());
+        assertEquals(new ApiSubError(FieldErrorFixture.getDefault(0)), apiError.getErrors().get(0));
+        assertEquals(new ApiSubError(FieldErrorFixture.getDefault(2)), apiError.getErrors().get(1));
+        assertEquals(new ApiSubError(FieldErrorFixture.getDefault(4)), apiError.getErrors().get(2));
+
+
+    }
+
+    @Test
+    @DisplayName("Should only have number of ApiSubErrors equivalent to number of FieldErrors")
+    void shouldHaveOnlyFieldErrors() {
+        //Given
+        var errors = List.of(mock(FieldError.class), mock(ObjectError.class));
+
+        //When
+        var apiError = new ApiError(HttpStatus.I_AM_A_TEAPOT, "TESTMESSAGE", errors);
+
+        //Then
+        assertEquals(1, apiError.getErrors().size());
+    }
+
+
+}

--- a/src/test/java/proj/kedabra/billsnap/ApiSubErrorTest.java
+++ b/src/test/java/proj/kedabra/billsnap/ApiSubErrorTest.java
@@ -1,0 +1,32 @@
+package proj.kedabra.billsnap;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ApiSubErrorTest {
+
+
+    @Test
+    @DisplayName("Should have all FieldError fields mapped")
+    void shouldHaveFieldErrorsMapped() {
+        //Given
+        var fieldError = FieldErrorFixture.getDefault(1);
+
+        //When
+        var subError = new ApiSubError(fieldError);
+
+        //Then
+        assertEquals("objectName1", subError.getObjectName());
+        assertEquals("field1", subError.getField());
+        assertEquals("rejectedValue1", subError.getRejectedValue());
+        assertEquals("defaultMessage1", subError.getMessage());
+        assertEquals("real1", subError.getErrorCode());
+        assertArrayEquals(new String[]{"one1", "two1", "three1"}, subError.getArguments());
+
+
+    }
+
+}

--- a/src/test/java/proj/kedabra/billsnap/BillSnapExceptionHandlerTest.java
+++ b/src/test/java/proj/kedabra/billsnap/BillSnapExceptionHandlerTest.java
@@ -1,0 +1,49 @@
+package proj.kedabra.billsnap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import proj.kedabra.billsnap.exception.FieldValidationException;
+
+class BillSnapExceptionHandlerTest {
+
+    private BillSnapExceptionHandler billSnapExceptionHandler = new BillSnapExceptionHandler();
+
+    @Test
+    @DisplayName("Should return ResponseEntity with FieldValidation")
+    void shouldReturnFieldValidationResponseEntity() {
+        //Given
+        var fieldError = FieldErrorFixture.getDefault(0);
+        var ex = new FieldValidationException("TEST", new Exception("hello"), List.of(fieldError));
+
+        //When
+        ResponseEntity<ApiError> response = billSnapExceptionHandler.handleFieldValidation(ex);
+
+        //Then
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(ex.getMessage(), Objects.requireNonNull(response.getBody()).getMessage());
+        assertEquals(new ApiSubError(fieldError), response.getBody().getErrors().get(0));
+    }
+
+    @Test
+    @DisplayName("Should return ResponseEntity with error 500 and unknown error message")
+    void shouldReturnUnknownResponseEntity() {
+        //Given
+        var ex = new UnsupportedOperationException("NOT THIS ERROR MESSAGE");
+
+        //When
+        ResponseEntity<ApiError> response = billSnapExceptionHandler.handleUnknownException(ex);
+
+        //Then
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Unknown error occurred. Please try again later", Objects.requireNonNull(response.getBody()).getMessage());
+    }
+
+}

--- a/src/test/java/proj/kedabra/billsnap/FieldErrorFixture.java
+++ b/src/test/java/proj/kedabra/billsnap/FieldErrorFixture.java
@@ -1,0 +1,19 @@
+package proj.kedabra.billsnap;
+
+import org.springframework.validation.FieldError;
+
+class FieldErrorFixture {
+
+    private FieldErrorFixture() {}
+
+    static FieldError getDefault(int uniqueIdentifier) {
+        final var objectName = "objectName" + uniqueIdentifier;
+        final var field = "field" + uniqueIdentifier;
+        final var rejectedValue = "rejectedValue" + uniqueIdentifier;
+        final var defaultMessage = "defaultMessage" + uniqueIdentifier;
+        final var code = new String[]{"code" + uniqueIdentifier, "real" + uniqueIdentifier};
+        final var arguments = new String[]{"one" + uniqueIdentifier, "two" + uniqueIdentifier, "three" + uniqueIdentifier};
+
+        return new FieldError(objectName, field, rejectedValue, false, code, arguments, defaultMessage);
+    }
+}


### PR DESCRIPTION
Adds an exception handler. 

- Exception handlers return a proper `ApiError` to the client
- Has an unknown exception handler if no other exception is caught and returns 500 
- Sorts out `FieldValidationErrors` which can be return from spring's own `BindingResult`