### PR TITLE
feat(#1rbay9): add JWT Authorization for private APIs

### DIFF
--- a/src/main/java/proj/kedabra/billsnap/config/SecurityConfig.java
+++ b/src/main/java/proj/kedabra/billsnap/config/SecurityConfig.java
@@ -4,19 +4,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.validation.Validator;
 
 import proj.kedabra.billsnap.business.service.impl.UserDetailsServiceImpl;
+import proj.kedabra.billsnap.security.JwtAuthenticationEntryPoint;
 import proj.kedabra.billsnap.security.JwtAuthenticationFailureHandler;
 import proj.kedabra.billsnap.security.JwtAuthenticationFilter;
 import proj.kedabra.billsnap.security.JwtAuthenticationSuccessHandler;
+import proj.kedabra.billsnap.security.JwtAuthorizationFilter;
 import proj.kedabra.billsnap.security.JwtService;
 
 @Configuration
@@ -47,18 +53,31 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Override
+    public void configure(WebSecurity web) {
+        web.ignoring().antMatchers("/v2/api-docs",
+                "/configuration/ui",
+                "/swagger-resources/**",
+                "/configuration/security",
+                "/swagger-ui.html",
+                "/webjars/**");
+    }
+
+    @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/**")
-                .permitAll()
-                .anyRequest()
-                .authenticated()
+                .antMatchers("/register", "/login").permitAll()
+                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .anyRequest().authenticated()
                 .and()
-                .addFilter(jwtAuthenticationFilter())
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthorizationFilter(), BasicAuthenticationFilter.class)
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint())
                 .and()
                 .headers()
                 .frameOptions()
@@ -72,6 +91,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         filter.setAuthenticationFailureHandler(new JwtAuthenticationFailureHandler(mapper));
 
         return filter;
+    }
+
+    private JwtAuthorizationFilter jwtAuthorizationFilter() throws Exception {
+        return new JwtAuthorizationFilter(authenticationManager(), jwtService);
+    }
+
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(mapper);
     }
 
     private PasswordEncoder passwordEncoder() {

--- a/src/main/java/proj/kedabra/billsnap/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/proj/kedabra/billsnap/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package proj.kedabra.billsnap.security;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import proj.kedabra.billsnap.presentation.ApiError;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private ObjectMapper mapper;
+
+    public JwtAuthenticationEntryPoint(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        ApiError apiError = new ApiError(HttpStatus.UNAUTHORIZED, "Access is unauthorized!");
+        response.setStatus(apiError.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(mapper.writeValueAsString(apiError));
+    }
+}

--- a/src/main/java/proj/kedabra/billsnap/security/JwtAuthorizationFilter.java
+++ b/src/main/java/proj/kedabra/billsnap/security/JwtAuthorizationFilter.java
@@ -1,0 +1,90 @@
+package proj.kedabra.billsnap.security;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.micrometer.core.instrument.util.StringUtils;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private JwtService jwtService;
+
+    private static final String TOKEN_HEADER = "Authorization";
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private static final String EXPIRED_TOKEN_LOG = "Request to parse expired JWT: {} failed: {}";
+
+    private static final String UNSUPPORTED_TOKEN_LOG = "Request to parse unsupported JWT: {} failed: {}";
+
+    private static final String MALFORMED_TOKEN_LOG = "Request to parse invalid JWT: {} failed: {}";
+
+    private static final String EMPTY_TOKEN_LOG = "Request to parse empty JWT: {} failed: {}";
+
+    private static final String INVALID_SIGNATURE_TOKEN_LOG = "Request to parse JWT with invalid signature: {} failed: {}";
+
+    private static final String INVALID_AUTHORIZATION_HEADER_LOG = "JWT is empty or does not start with 'Bearer ' in Authorization header";
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtService jwtService) {
+        super(authenticationManager);
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws IOException, ServletException {
+        Optional<UsernamePasswordAuthenticationToken> authentication = getAuthentication(request);
+        if (authentication.isEmpty()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        SecurityContextHolder.getContext().setAuthentication(authentication.get());
+        filterChain.doFilter(request, response);
+    }
+
+    private Optional<UsernamePasswordAuthenticationToken> getAuthentication(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+        if (StringUtils.isNotEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            try {
+                String username = jwtService.getJwtUsername(token);
+                Collection<GrantedAuthority> authorities = jwtService.getJwtAuthorities(token);
+
+                if (StringUtils.isNotEmpty(username)) {
+                    return Optional.of(new UsernamePasswordAuthenticationToken(username, null, authorities));
+                }
+            } catch (ExpiredJwtException ex) {
+                log.warn(EXPIRED_TOKEN_LOG, token, ex.getMessage());
+            } catch (UnsupportedJwtException ex) {
+                log.warn(UNSUPPORTED_TOKEN_LOG, token, ex.getMessage());
+            } catch (MalformedJwtException ex) {
+                log.warn(MALFORMED_TOKEN_LOG, token, ex.getMessage());
+            } catch (IllegalArgumentException ex) {
+                log.warn(EMPTY_TOKEN_LOG, token, ex.getMessage());
+            } catch (SignatureException ex) {
+                log.warn(INVALID_SIGNATURE_TOKEN_LOG, token, ex.getMessage());
+            }
+        } else {
+            log.warn(INVALID_AUTHORIZATION_HEADER_LOG);
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/proj/kedabra/billsnap/presentation/controllers/TestPrivateController.java
+++ b/src/test/java/proj/kedabra/billsnap/presentation/controllers/TestPrivateController.java
@@ -1,0 +1,14 @@
+package proj.kedabra.billsnap.presentation.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestPrivateController {
+
+    @GetMapping("/api-test/private-api-test-controller")
+    public String getMessage() {
+        return "Private API controller";
+    }
+
+}

--- a/src/test/java/proj/kedabra/billsnap/security/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/proj/kedabra/billsnap/security/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,64 @@
+package proj.kedabra.billsnap.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.CredentialsExpiredException;
+
+import proj.kedabra.billsnap.presentation.ApiError;
+
+class JwtAuthenticationEntryPointTest {
+
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final String ACCESS_UNAUTHORIZED = "Access is unauthorized!";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        jwtAuthenticationEntryPoint = new JwtAuthenticationEntryPoint(mapper);
+    }
+
+    @Test
+    @DisplayName("Should return 401 Unauthorized Error in Response")
+    void ResponseShouldHaveUnauthorizedError() throws Exception {
+        //Given
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        CredentialsExpiredException exception = new CredentialsExpiredException("");
+
+        //When
+        jwtAuthenticationEntryPoint.commence(req, mockResponse, exception);
+
+        //Then
+        ApiError error = convertContentToApiError(mockResponse.getContentAsString());
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, mockResponse.getStatus());
+    }
+
+    private ApiError convertContentToApiError(String content) throws Exception {
+        String formattedTimestamp = LocalDateTime.now(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss"));
+
+        JsonNode node = mapper.readTree(content);
+        ((ObjectNode) node).put("timestamp", formattedTimestamp);
+        String modifiedContent = node.toString();
+        return mapper.readValue(modifiedContent, ApiError.class);
+    }
+}

--- a/src/test/java/proj/kedabra/billsnap/security/JwtAuthorizationFilterTest.java
+++ b/src/test/java/proj/kedabra/billsnap/security/JwtAuthorizationFilterTest.java
@@ -1,0 +1,186 @@
+package proj.kedabra.billsnap.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+import proj.kedabra.billsnap.fixtures.UserFixture;
+
+class JwtAuthorizationFilterTest {
+
+    private JwtAuthorizationFilter filter;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private static final String MALFORMED_TOKEN = "malformed-token";
+
+    private static final String INVALID_SIGNATURE_TOKEN = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQHVzZXIuY29tIiwiZXhwIjoxNTY2ODU" +
+            "5MTYyLCJyb2xlcyI6WyJST0xFX1VTRVIiXX0.aNcyQfL6G8HM0t83uGHuwb9xehz4S-xbvoG7bQwsoR-NUNn-URcZV_YFvp3rx5F39HU5yUJSHXMa-OcBkeWJhA";
+
+    private static final String EXPIRED_TOKEN = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdHJpbmdAZW1haWwuY29tIiwiZXhwIjoxNTY2ODY1MDY2" +
+            "LCJyb2xlcyI6WyJST0xFX1VTRVIiXX0.C9cYU1bb7s--S5wkSI1ofPGYlatG4e53IerkBhzkcuzM-hoki8lgv2-JdyoKC9psGnCDT-TCbiKlNwDtZ4whjA";
+
+    private static final String UNSUPPORTED_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibm" +
+            "FtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        filter = new JwtAuthorizationFilter(authenticationManager, jwtService);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    @DisplayName("Request to private API with valid token should set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithValidTokenShouldReturnSuccess() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        User defaultUser = UserFixture.getDefault();
+        when(jwtService.getJwtUsername(any())).thenReturn(defaultUser.getUsername());
+        when(jwtService.getJwtAuthorities(any())).thenReturn(defaultUser.getAuthorities());
+
+        final String testToken = TOKEN_PREFIX + "test-token";
+        req.addHeader("Authorization", testToken);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext).setAuthentication(any());
+    }
+
+    @Test
+    @DisplayName("Request to private API where token has no 'Bearer ' should not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithNoBearerTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        final String testToken = "test token";
+        req.addHeader("Authorization", testToken);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());
+    }
+
+    @Test
+    @DisplayName("Request to private API with expired token should not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithExpiredTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        req.addHeader("Authorization", TOKEN_PREFIX + EXPIRED_TOKEN);
+
+        when(jwtService.getJwtUsername(any())).thenThrow(ExpiredJwtException.class);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());}
+
+    @Test
+    @DisplayName("Request to private API with Malformed token should not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithMalformedTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        req.addHeader("Authorization", TOKEN_PREFIX + MALFORMED_TOKEN);
+
+        when(jwtService.getJwtUsername(any())).thenThrow(MalformedJwtException.class);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());}
+
+    @Test
+    @DisplayName("Request to private API with Unsupported token should not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithUnsupportedTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        req.addHeader("Authorization", TOKEN_PREFIX + UNSUPPORTED_TOKEN);
+
+        when(jwtService.getJwtUsername(any())).thenThrow(UnsupportedJwtException.class);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());}
+
+    @Test
+    @DisplayName("Request to private API with empty token should not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithEmptyTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        req.addHeader("Authorization", TOKEN_PREFIX + "");
+
+        when(jwtService.getJwtUsername(any())).thenThrow(IllegalArgumentException.class);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());}
+
+    @Test
+    @DisplayName("Request to private API with invalid signature token not set Authentication to SecurityContext")
+    void RequestToPrivateAPIWithInvalidSignatureTokenShouldReturnError() throws Exception {
+        //Given
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        req.addHeader("Authorization", TOKEN_PREFIX + INVALID_SIGNATURE_TOKEN);
+
+        when(jwtService.getJwtUsername(any())).thenThrow(SignatureException.class);
+
+        //When
+        filter.doFilterInternal(req, resp, filterChain);
+
+        //Then
+        verify(securityContext, never()).setAuthentication(any());}
+}

--- a/src/test/java/proj/kedabra/billsnap/security/JwtAuthorizationIT.java
+++ b/src/test/java/proj/kedabra/billsnap/security/JwtAuthorizationIT.java
@@ -1,0 +1,169 @@
+package proj.kedabra.billsnap.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.annotation.Resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import proj.kedabra.billsnap.fixtures.UserFixture;
+import proj.kedabra.billsnap.presentation.ApiError;
+import proj.kedabra.billsnap.utils.SpringProfiles;
+
+@Tag("integration")
+@ActiveProfiles(SpringProfiles.TEST)
+@SpringBootTest
+@AutoConfigureMockMvc
+@SuppressWarnings("squid:S00112")
+@AutoConfigureTestDatabase
+class JwtAuthorizationIT {
+
+    @Resource
+    private FilterChainProxy springSecurityFilterChain;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private static final String PRIVATE_ENDPOINT = "/api-test/private-api-test-controller";
+
+    private static final String PRIVATE_ENDPOINT_MESSAGE = "Private API controller";
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private static final String ACCESS_UNAUTHORIZED = "Access is unauthorized!";
+
+    private static final String MALFORMED_TOKEN = "malformed-token";
+
+    private static final String INVALID_SIGNATURE_TOKEN = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQHVzZXIuY29tIiwiZXhwIjoxNTY2ODU" +
+            "5MTYyLCJyb2xlcyI6WyJST0xFX1VTRVIiXX0.aNcyQfL6G8HM0t83uGHuwb9xehz4S-xbvoG7bQwsoR-NUNn-URcZV_YFvp3rx5F39HU5yUJSHXMa-OcBkeWJhA";
+
+    private static final String EXPIRED_TOKEN = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdHJpbmdAZW1haWwuY29tIiwiZXhwIjoxNTY2ODY1MDY2" +
+            "LCJyb2xlcyI6WyJST0xFX1VTRVIiXX0.C9cYU1bb7s--S5wkSI1ofPGYlatG4e53IerkBhzkcuzM-hoki8lgv2-JdyoKC9psGnCDT-TCbiKlNwDtZ4whjA";
+
+    private static final String UNSUPPORTED_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibm" +
+            "FtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .addFilter(springSecurityFilterChain)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Request to private API with valid token should have success response")
+    void RequestToPrivateAPIWithValidTokenShouldReturnSuccess() throws Exception {
+        //Given
+        User defaultUser = UserFixture.getDefault();
+        String token = TOKEN_PREFIX + jwtService.generateToken(defaultUser);
+
+        //When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", token)).andExpect(status().is2xxSuccessful()).andReturn();
+        assertEquals(PRIVATE_ENDPOINT_MESSAGE, result.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("Request to private API where token has no 'Bearer ' should return error response")
+    void RequestToPrivateAPIWithNoBearerTokenShouldReturnError() throws Exception {
+        //Given
+        User defaultUser = UserFixture.getDefault();
+        String token = jwtService.generateToken(defaultUser);
+
+        //When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", token)).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+    @Test
+    @DisplayName("Request to private API with expired token should return error")
+    void RequestToPrivateAPIWithExpiredTokenShouldReturnError() throws Exception {
+        //Given/When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", EXPIRED_TOKEN)).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+    @Test
+    @DisplayName("Request to private API with Malformed token should return error")
+    void RequestToPrivateAPIWithMalformedTokenShouldReturnError() throws Exception {
+        //Given/When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", MALFORMED_TOKEN)).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+    @Test
+    @DisplayName("Request to private API with Unsupported token should return error")
+    void RequestToPrivateAPIWithUnsupportedTokenShouldReturnError() throws Exception {
+        //Given/When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", UNSUPPORTED_TOKEN)).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+    @Test
+    @DisplayName("Request to private API with empty token should return error")
+    void RequestToPrivateAPIWithEmptyTokenShouldReturnError() throws Exception {
+        //Given/When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", "")).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+    @Test
+    @DisplayName("Request to private API with invalid signature token should return error")
+    void RequestToPrivateAPIWithInvalidSignatureTokenShouldReturnError() throws Exception {
+        //Given/When/Then
+        MvcResult result = mockMvc.perform(get(PRIVATE_ENDPOINT).header("Authorization", INVALID_SIGNATURE_TOKEN)).andExpect(status().isUnauthorized()).andReturn();
+        String content = result.getResponse().getContentAsString();
+        ApiError error = mapper.readValue(content, ApiError.class);
+
+        assertEquals(ACCESS_UNAUTHORIZED, error.getMessage());
+        assertEquals(0, error.getErrors().size());
+    }
+
+}


### PR DESCRIPTION
Adds a JWT Authorization filter to the app to verify valid Bearer tokens in requests to private APIs