### PR TITLE
fix(#5cbe6a)(#5cbec6)(#5cbeha): fix Associate Users/Modify Bills bugs

### DIFF
--- a/src/main/java/proj/kedabra/billsnap/business/service/impl/BillServiceImpl.java
+++ b/src/main/java/proj/kedabra/billsnap/business/service/impl/BillServiceImpl.java
@@ -153,6 +153,7 @@ public class BillServiceImpl implements BillService {
     @Transactional(rollbackFor = Exception.class)
     public Bill associateItemsToAccountBill(AssociateBillDTO associateBillDTO) {
         verifyPercentagesAreIntegerValued(associateBillDTO);
+        verifyNoDuplicateEmails(associateBillDTO);
         final var bill = getBill(associateBillDTO.getId());
         final List<ItemAssociationDTO> items = associateBillDTO.getItems();
         verifyExistenceOfAccountsInBill(bill, items);
@@ -227,6 +228,18 @@ public class BillServiceImpl implements BillService {
 
         if (!nonIntegerList.isEmpty()) {
             throw new IllegalArgumentException(ErrorMessageEnum.GIVEN_VALUES_NOT_INTEGER_VALUED.getMessage(nonIntegerList.toString()));
+        }
+    }
+
+    private void verifyNoDuplicateEmails(AssociateBillDTO associateBillDTO) {
+        final HashSet<String> allEmails = new HashSet<>();
+        final Set<String> duplicateSet = associateBillDTO.getItems().stream()
+                .map(ItemAssociationDTO::getEmail)
+                .filter(email -> !allEmails.add(email)) //Set.add() returns false if the item was already in the set
+                .collect(Collectors.toSet());
+
+        if (!duplicateSet.isEmpty()) {
+            throw new IllegalArgumentException(ErrorMessageEnum.DUPLICATE_EMAILS_IN_ASSOCIATE_USERS.getMessage(duplicateSet.toString()));
         }
     }
 

--- a/src/main/java/proj/kedabra/billsnap/utils/ErrorMessageEnum.java
+++ b/src/main/java/proj/kedabra/billsnap/utils/ErrorMessageEnum.java
@@ -26,8 +26,9 @@ public enum ErrorMessageEnum {
     SOME_ITEMS_NONEXISTENT_IN_BILL("Not all items exist in the bill: {}"),
     LIST_ACCOUNT_ALREADY_IN_BILL("One or more accounts is already invited or part of the bill: {}"),
     USER_IS_NOT_BILL_RESPONSIBLE("The user making the request is not the Bill responsible"),
+    GIVEN_VALUES_NOT_INTEGER_VALUED("The given percentages are not integer valued: {}"),
+    DUPLICATE_EMAILS_IN_ASSOCIATE_USERS("There are duplicate emails being called: {}"),
     BILL_IS_NOT_OPEN("The bill is not in Open status."),
-    GIVEN_VALUES_NOT_INTEGER_VALUED("The given values are not integer valued: {}"),
 
     //=========================================TESTING ONLY===============================================
     TEST_DIFFERENT_POSITION_PARAMS("First Param: {} , Second Param: {} , Third Param: {}");

--- a/src/test/java/proj/kedabra/billsnap/business/service/impl/BillServiceImplIT.java
+++ b/src/test/java/proj/kedabra/billsnap/business/service/impl/BillServiceImplIT.java
@@ -477,6 +477,36 @@ class BillServiceImplIT {
     }
 
     @Test
+    @DisplayName("Should throw Exception if /PATCH Associate Users Bill call contains duplicate email")
+    void shouldThrowExceptionIfAssociateBillCallContainsDuplicateEmail() {
+        //Given bill with 2 users
+        final String billResponsible = "user@withABill.com";
+        final BigDecimal fifty = BigDecimal.valueOf(50);
+        final long existentBillId = 1003L;
+
+        final var itemAssociationDTO1 = ItemAssociationDTOFixture.getDefault();
+        itemAssociationDTO1.setEmail(billResponsible);
+        itemAssociationDTO1.getItems().forEach(itemPercentageDTO -> {
+            itemPercentageDTO.setItemId(9001L);
+            itemPercentageDTO.setPercentage(fifty);
+        });
+        final var itemAssociationDTO2 = ItemAssociationDTOFixture.getDefault();
+        itemAssociationDTO2.setEmail(billResponsible);
+        itemAssociationDTO2.getItems().forEach(itemPercentageDTO -> {
+            itemPercentageDTO.setItemId(8999L);
+            itemPercentageDTO.setPercentage(fifty);
+        });
+
+        final var associateBillDTO = AssociateBillDTOFixture.getDefault();
+        associateBillDTO.setItems(List.of(itemAssociationDTO1, itemAssociationDTO2));
+
+        //When/Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> billService.associateItemsToAccountBill(associateBillDTO))
+                .withMessage(ErrorMessageEnum.DUPLICATE_EMAILS_IN_ASSOCIATE_USERS.getMessage(List.of(billResponsible).toString()));
+    }
+
+    @Test
     @DisplayName("Should throw Exception if /PATCH Associate Users Bill call contains user not in bill")
     void shouldThrowExceptionIfAssociateBillCallContainsUserNotInBill() {
         //Given bill with 2 users

--- a/src/test/java/proj/kedabra/billsnap/business/service/impl/BillServiceImplTest.java
+++ b/src/test/java/proj/kedabra/billsnap/business/service/impl/BillServiceImplTest.java
@@ -308,6 +308,36 @@ class BillServiceImplTest {
     }
 
     @Test
+    @DisplayName("Should throw Exception if /PATCH Associate Users Bill call contains duplicate email")
+    void shouldThrowExceptionIfAssociateBillCallContainsDuplicateEmail() {
+        //Given bill with 2 users
+        final String billResponsible = "user@withABill.com";
+        final BigDecimal fifty = BigDecimal.valueOf(50);
+        final long existentBillId = 1003L;
+
+        final var itemAssociationDTO1 = ItemAssociationDTOFixture.getDefault();
+        itemAssociationDTO1.setEmail(billResponsible);
+        itemAssociationDTO1.getItems().forEach(itemPercentageDTO -> {
+            itemPercentageDTO.setItemId(9001L);
+            itemPercentageDTO.setPercentage(fifty);
+        });
+        final var itemAssociationDTO2 = ItemAssociationDTOFixture.getDefault();
+        itemAssociationDTO2.setEmail(billResponsible);
+        itemAssociationDTO2.getItems().forEach(itemPercentageDTO -> {
+            itemPercentageDTO.setItemId(8999L);
+            itemPercentageDTO.setPercentage(fifty);
+        });
+
+        final var associateBillDTO = AssociateBillDTOFixture.getDefault();
+        associateBillDTO.setItems(List.of(itemAssociationDTO1, itemAssociationDTO2));
+
+        //When/Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> billService.associateItemsToAccountBill(associateBillDTO))
+                .withMessage(ErrorMessageEnum.DUPLICATE_EMAILS_IN_ASSOCIATE_USERS.getMessage(List.of(billResponsible).toString()));
+    }
+
+    @Test
     @DisplayName("Should throw Exception if /PATCH Associate Users Bill call contains user not in bill")
     void shouldThrowExceptionIfAssociateBillCallContainsUserNotInBill() {
         //Given bill with 2 users


### PR DESCRIPTION
Prod fixes for following stories:
- #5cbe6a: Unable to associate 2 users to an item
- #5cbec6: Non-Integer values are accepted in Associate users
- #5cbeha: Ability to have two of the same emails on the same item on associate users call