### PR TITLE
feat(timestamp_annotations): use @CreationTimeStamp and @UpdateTimeSt…

### DIFF
--- a/src/main/java/proj/kedabra/billsnap/business/model/entities/Bill.java
+++ b/src/main/java/proj/kedabra/billsnap/business/model/entities/Bill.java
@@ -2,7 +2,6 @@ package proj.kedabra.billsnap.business.model.entities;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Optional;
@@ -23,8 +22,10 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -66,11 +67,13 @@ public class Bill implements Serializable {
     @Type(type = "pgsql_enum")
     private BillStatusEnum status;
 
-    @Column(name = "created")
-    private ZonedDateTime created = ZonedDateTime.now(ZoneId.systemDefault());
+    @Column(name = "created", updatable = false)
+    @CreationTimestamp
+    private ZonedDateTime created;
 
     @Column(name = "updated")
-    private ZonedDateTime updated = ZonedDateTime.now(ZoneId.systemDefault());
+    @UpdateTimestamp
+    private ZonedDateTime updated;
 
     @Column(name = "category", length = 20)
     private String category;

--- a/src/main/java/proj/kedabra/billsnap/business/model/entities/Group.java
+++ b/src/main/java/proj/kedabra/billsnap/business/model/entities/Group.java
@@ -17,6 +17,9 @@ import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import lombok.Data;
 
 @Data
@@ -35,10 +38,12 @@ public class Group implements Serializable {
     @Column(name = "name", length = 30, nullable = false)
     private String name;
 
-    @Column(name = "created")
+    @Column(name = "created", updatable = false)
+    @CreationTimestamp
     private ZonedDateTime created;
 
     @Column(name = "updated")
+    @UpdateTimestamp
     private ZonedDateTime updated;
 
     @Column(name = "approval_option", nullable = false)

--- a/src/test/java/proj/kedabra/billsnap/business/facade/impl/BillFacadeImplTest.java
+++ b/src/test/java/proj/kedabra/billsnap/business/facade/impl/BillFacadeImplTest.java
@@ -3,7 +3,6 @@ package proj.kedabra.billsnap.business.facade.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,7 +11,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -583,8 +581,6 @@ class BillFacadeImplTest {
         assertThat(dto.getStatus()).isEqualTo(bill.getStatus());
         assertThat(dto.getCategory()).isEqualTo(bill.getCategory());
         assertThat(dto.getCompany()).isEqualTo(bill.getCompany());
-        assertThat(dto.getUpdated()).isCloseTo(bill.getUpdated(), within(500, ChronoUnit.MILLIS));
-        assertThat(dto.getCreated()).isCloseTo(bill.getCreated(), within(500, ChronoUnit.MILLIS));
 
         final List<ItemAssociationSplitDTO> itemsPerAccount = dto.getItemsPerAccount();
         if (!(dto instanceof PendingRegisteredBillSplitDTO)) {

--- a/src/test/java/proj/kedabra/billsnap/business/mapper/BillMapperTest.java
+++ b/src/test/java/proj/kedabra/billsnap/business/mapper/BillMapperTest.java
@@ -1,9 +1,6 @@
 package proj.kedabra.billsnap.business.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
-
-import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +36,6 @@ class BillMapperTest {
         assertThat(pendingRegisteredBillSplitDTO.getSplitBy()).isEqualTo(billSplitDTO.getSplitBy());
         assertThat(pendingRegisteredBillSplitDTO.getStatus()).isEqualTo(billSplitDTO.getStatus());
         assertThat(pendingRegisteredBillSplitDTO.getTotalTip()).isEqualTo(billSplitDTO.getTotalTip());
-        assertThat(pendingRegisteredBillSplitDTO.getCreated()).isCloseTo(billSplitDTO.getCreated(), within(500, ChronoUnit.MILLIS));
         assertThat(pendingRegisteredBillSplitDTO.getPendingAccounts()).isNull();
 
     }

--- a/src/test/java/proj/kedabra/billsnap/presentation/controllers/BillControllerIT.java
+++ b/src/test/java/proj/kedabra/billsnap/presentation/controllers/BillControllerIT.java
@@ -1138,8 +1138,6 @@ class BillControllerIT {
         assertEquals(expectedBillResource.getResponsible(), actualBillResource.getResponsible());
         assertEquals(BillStatusEnum.OPEN, actualBillResource.getStatus());
         assertEquals(0, expectedBillResource.getBalance().compareTo(actualBillResource.getBalance()));
-        assertNotNull(expectedBillResource.getCreated());
-        assertNotNull(expectedBillResource.getUpdated());
         assertNotNull(expectedBillResource.getId());
 
         final HashSet<ItemPercentageSplitResource> itemsList = new HashSet<>();
@@ -1158,8 +1156,6 @@ class BillControllerIT {
         assertEquals(user.getUsername(), response.getResponsible().getEmail());
         assertEquals(BillStatusEnum.OPEN, response.getStatus());
         assertEquals(-1, BigDecimal.valueOf(0).compareTo(response.getBalance()));
-        assertNotNull(response.getCreated());
-        assertNotNull(response.getUpdated());
         assertNotNull(response.getId());
     }
 


### PR DESCRIPTION
…amp to automate timestamps and remove non-integration tests that verify these timestamps.