### PR TITLE
feat(#9mn1b1_#a6k58k): add authorities depending on the user's rights…

### DIFF
--- a/src/main/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImpl.java
@@ -1,15 +1,20 @@
 package proj.kedabra.billsnap.business.service.impl;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import proj.kedabra.billsnap.business.model.entities.Account;
+import proj.kedabra.billsnap.business.model.entities.AccountBill;
 import proj.kedabra.billsnap.business.repository.AccountRepository;
 import proj.kedabra.billsnap.utils.ErrorMessageEnum;
 
@@ -24,16 +29,31 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String email){
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) {
         Optional<Account> optionalUser = Optional.ofNullable(accountRepository.getAccountByEmail(email));
-        return toUserDetails(optionalUser.orElseThrow(
-                () -> new UsernameNotFoundException(ErrorMessageEnum.NO_USER_FOUND_WITH_EMAIL.getMessage(email))));
+        return optionalUser.map(this::toUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException(ErrorMessageEnum.NO_USER_FOUND_WITH_EMAIL.getMessage(email)));
+
     }
 
     private UserDetails toUserDetails(Account user) {
+
+        var authorities = new ArrayList<GrantedAuthority>();
+
+        user.getBills().stream().map(AccountBill::getBill).forEach(bill -> {
+            //for all bills where the user is responsible, we set them to have the authority prefix: RESPONSIBLE_
+            if (bill.getResponsible().getEmail().equals(user.getEmail())) {
+                authorities.add(new SimpleGrantedAuthority("RESPONSIBLE_" + bill.getId()));
+            }
+
+            //all other participants of the bill will simply get the billId in their authority
+            authorities.add(new SimpleGrantedAuthority(bill.getId().toString()));
+        });
+
         return User.withUsername(user.getEmail())
                 .password(user.getPassword())
-                .roles("USER")
+                .authorities(authorities)
                 .build();
     }
 

--- a/src/main/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImpl.java
@@ -31,7 +31,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String email) {
-        Optional<Account> optionalUser = Optional.ofNullable(accountRepository.getAccountByEmail(email));
+        final Optional<Account> optionalUser = Optional.ofNullable(accountRepository.getAccountByEmail(email));
         return optionalUser.map(this::toUserDetails)
                 .orElseThrow(() -> new UsernameNotFoundException(ErrorMessageEnum.NO_USER_FOUND_WITH_EMAIL.getMessage(email)));
 
@@ -39,7 +39,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     private UserDetails toUserDetails(Account user) {
 
-        var authorities = new ArrayList<GrantedAuthority>();
+        final var authorities = new ArrayList<GrantedAuthority>();
 
         user.getBills().stream().map(AccountBill::getBill).forEach(bill -> {
             //for all bills where the user is responsible, we set them to have the authority prefix: RESPONSIBLE_

--- a/src/main/resources/scripts/insert_data.sql
+++ b/src/main/resources/scripts/insert_data.sql
@@ -210,6 +210,11 @@ INSERT INTO bill (id, name, responsible, creator, status, created, updated, cate
 VALUES (1306, 'bill pagination 7', 11000, 11000, 'OPEN', to_date('2019-05-05', 'yyyy-MM-dd'), current_timestamp, 'restaurant', null, 0, 15, null, 'ITEM', null,
         1);
 
+INSERT INTO bill (id, name, responsible, creator, status, created, updated, category, company, occurrence, tip_percent,
+                  tip_amount, split_by, location_id, active)
+VALUES (1400, 'user details resp', 2000, 2000, 'OPEN', to_date('2019-05-05', 'yyyy-MM-dd'), current_timestamp, 'restaurant', null, 0, 15, null, 'ITEM', null,
+        1);
+
 
 INSERT INTO bills_vs_accounts (bill_id, account_id, percentage, status)
 VALUES (1100, 5000, 100, 'ACCEPTED');
@@ -272,6 +277,8 @@ INSERT INTO bills_vs_accounts (bill_id, account_id, percentage, status)
 VALUES (1305, 11000, 100, 'ACCEPTED');
 INSERT INTO bills_vs_accounts (bill_id, account_id, percentage, status)
 VALUES (1306, 11000, 100, 'PENDING');
+INSERT INTO bills_vs_accounts (bill_id, account_id, percentage, status)
+VALUES (1400, 2000, 100, 'ACCEPTED');
 
 INSERT INTO item (id, bill_id, name, cost)
 VALUES (1000, 1004, 'potatoes', 69.00);

--- a/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplIT.java
+++ b/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplIT.java
@@ -38,11 +38,11 @@ class UserDetailsServiceImplIT {
     @DisplayName("Should return UserDetails object built from inputted Account object")
     void shouldReturnUserDetailsBuiltFromAccount() {
         //Given
-        var existingEmail = "userdetails@service.com";
-        Account accountObj = accountRepository.getAccountByEmail(existingEmail);
+        final var existingEmail = "userdetails@service.com";
+        final Account accountObj = accountRepository.getAccountByEmail(existingEmail);
 
         //When
-        UserDetails userDetailsObj = userDetailsServiceImpl.loadUserByUsername(existingEmail);
+        final UserDetails userDetailsObj = userDetailsServiceImpl.loadUserByUsername(existingEmail);
 
         //Then
         assertThat(userDetailsObj.getUsername()).isEqualTo(accountObj.getEmail());
@@ -55,10 +55,10 @@ class UserDetailsServiceImplIT {
     @DisplayName("Should return exception if User cannot be loaded by Username (email)")
     void shouldReturnExceptionIfUserCannotBeLoadedByUsername() {
         //Given
-        var nonExistentEmail = "nonexistent@email.com";
+        final var nonExistentEmail = "nonexistent@email.com";
 
         //When/Then
-        UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class,
+        final UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class,
                 () -> userDetailsServiceImpl.loadUserByUsername(nonExistentEmail));
         assertThat(ex.getMessage()).isEqualTo(String.format("No user found with email '%s'", nonExistentEmail));
     }

--- a/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplTest.java
+++ b/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplTest.java
@@ -1,32 +1,35 @@
 package proj.kedabra.billsnap.business.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
+import proj.kedabra.billsnap.business.model.entities.AccountBill;
 import proj.kedabra.billsnap.business.repository.AccountRepository;
 import proj.kedabra.billsnap.fixtures.AccountEntityFixture;
+import proj.kedabra.billsnap.fixtures.BillEntityFixture;
 
+@ExtendWith(MockitoExtension.class)
 class UserDetailsServiceImplTest {
 
+    @InjectMocks
     private UserDetailsServiceImpl userDetailsService;
 
     @Mock
     private AccountRepository accountRepository;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.initMocks(this);
-        userDetailsService = new UserDetailsServiceImpl(accountRepository);
-    }
 
     @Test
     @DisplayName("Should return exception if account cannot be retrieved from database")
@@ -37,12 +40,12 @@ class UserDetailsServiceImplTest {
 
         //When /Then
         UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class, () -> userDetailsService.loadUserByUsername(nonExistentEmail));
-        assertEquals(String.format("No user found with email '%s'", nonExistentEmail), ex.getMessage());
+        assertThat(ex.getMessage()).isEqualTo(String.format("No user found with email '%s'", nonExistentEmail));
     }
 
     @Test
     @DisplayName("Should return UserDetails built from inputted Account")
-    void ShouldReturnUserDetailsBuiltFromAccount(){
+    void ShouldReturnUserDetailsBuiltFromAccount() {
         //Given
         var accountObj = AccountEntityFixture.getDefaultAccount();
         final String email = "userdetails@unittest.com";
@@ -53,9 +56,39 @@ class UserDetailsServiceImplTest {
         UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
 
         //Then
-        assertEquals(accountObj.getEmail(), userDetailsObj.getUsername());
-        assertEquals(accountObj.getPassword(), userDetailsObj.getPassword());
-        assertEquals(1,  userDetailsObj.getAuthorities().size());
-        assertEquals("ROLE_USER", userDetailsObj.getAuthorities().stream().findFirst().orElseThrow().getAuthority());
+        assertThat(userDetailsObj.getUsername()).isEqualTo(accountObj.getEmail());
+        assertThat(userDetailsObj.getPassword()).isEqualTo(accountObj.getPassword());
+        assertThat(userDetailsObj.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return UserDetails built from inputted Account with rights of responsible and normal participants")
+    void ShouldReturnUserDetailsBuiltFromAccountWithResponsibleAndNormalRights() {
+        //Given
+        var accountObj = AccountEntityFixture.getDefaultAccount();
+        final String email = "userdetails@unittest.com";
+        accountObj.setEmail(email);
+        when(accountRepository.getAccountByEmail(email)).thenReturn(accountObj);
+        final var bill1 = BillEntityFixture.getDefault();
+        bill1.setResponsible(accountObj);
+        final var bill2 = BillEntityFixture.getDefault();
+        bill2.setId(123L);
+
+        final var accountBill1 = new AccountBill();
+        accountBill1.setBill(bill1);
+        final var accountBill2 = new AccountBill();
+        accountBill2.setBill(bill2);
+
+        accountObj.setBills(Set.of(accountBill1, accountBill2));
+
+        //When
+        UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
+
+        //Then
+        assertThat(userDetailsObj.getUsername()).isEqualTo(accountObj.getEmail());
+        assertThat(userDetailsObj.getPassword()).isEqualTo(accountObj.getPassword());
+        assertThat(userDetailsObj.getAuthorities()).hasSize(3);
+        final var authorities = userDetailsObj.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList());
+        assertThat(authorities).containsOnly("RESPONSIBLE_" + bill1.getId(), bill1.getId().toString(), bill2.getId().toString());
     }
 }

--- a/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplTest.java
+++ b/src/test/java/proj/kedabra/billsnap/business/service/impl/UserDetailsServiceImplTest.java
@@ -39,7 +39,7 @@ class UserDetailsServiceImplTest {
         when(accountRepository.getAccountByEmail(nonExistentEmail)).thenReturn(null);
 
         //When /Then
-        UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class, () -> userDetailsService.loadUserByUsername(nonExistentEmail));
+        final UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class, () -> userDetailsService.loadUserByUsername(nonExistentEmail));
         assertThat(ex.getMessage()).isEqualTo(String.format("No user found with email '%s'", nonExistentEmail));
     }
 
@@ -47,13 +47,13 @@ class UserDetailsServiceImplTest {
     @DisplayName("Should return UserDetails built from inputted Account")
     void ShouldReturnUserDetailsBuiltFromAccount() {
         //Given
-        var accountObj = AccountEntityFixture.getDefaultAccount();
+        final var accountObj = AccountEntityFixture.getDefaultAccount();
         final String email = "userdetails@unittest.com";
         accountObj.setEmail(email);
         when(accountRepository.getAccountByEmail(email)).thenReturn(accountObj);
 
         //When
-        UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
+        final UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
 
         //Then
         assertThat(userDetailsObj.getUsername()).isEqualTo(accountObj.getEmail());
@@ -65,7 +65,7 @@ class UserDetailsServiceImplTest {
     @DisplayName("Should return UserDetails built from inputted Account with rights of responsible and normal participants")
     void ShouldReturnUserDetailsBuiltFromAccountWithResponsibleAndNormalRights() {
         //Given
-        var accountObj = AccountEntityFixture.getDefaultAccount();
+        final var accountObj = AccountEntityFixture.getDefaultAccount();
         final String email = "userdetails@unittest.com";
         accountObj.setEmail(email);
         when(accountRepository.getAccountByEmail(email)).thenReturn(accountObj);
@@ -82,7 +82,7 @@ class UserDetailsServiceImplTest {
         accountObj.setBills(Set.of(accountBill1, accountBill2));
 
         //When
-        UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
+        final UserDetails userDetailsObj = userDetailsService.loadUserByUsername(email);
 
         //Then
         assertThat(userDetailsObj.getUsername()).isEqualTo(accountObj.getEmail());


### PR DESCRIPTION
… on bills to user details

I have no added a caching annotation to the load user details because I think it might cause more of a headache handling all the cache of users as bills change responsible or when bills are added to users. For the time being, we'll leave it as is. If we need to add caching afterwards because of slow performance, then we will optimize it at that point. 